### PR TITLE
docs: highlight citation formatting in Changen2 README

### DIFF
--- a/torchange/models/changen2/README.md
+++ b/torchange/models/changen2/README.md
@@ -83,7 +83,7 @@ We also provide a convenient version you can load via huggingface's datasets lib
 
 ## Citation
 If you find our project helpful, we would greatly appreciate it if you could kindly cite our papers:
-```
+```bibtex
 @article{changen2,
   author={Zheng, Zhuo and Ermon, Stefano and Kim, Dongjun and Zhang, Liangpei and Zhong, Yanfei},
   journal={IEEE Transactions on Pattern Analysis and Machine Intelligence}, 


### PR DESCRIPTION
## Summary
- specify bibtex syntax highlighting for the citation block in Changen2 README
- ensure file ends with a trailing newline to prevent prompt bleed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689578bb38b883298b98039ca2770ae0