### PR TITLE
Refactor utils: extract inline examples, add examples script, document outputs/masks, and remove README utilities section

### DIFF
--- a/examples/utils_output_masks.py
+++ b/examples/utils_output_masks.py
@@ -1,0 +1,42 @@
+"""Small usage examples for torchange.utils outputs and masks."""
+import torch
+
+from torchange.utils.mask_data import Mask
+from torchange.utils.outputs import ChangeDetectionModelOutput
+
+
+def demo_change_detection_output() -> None:
+    t1 = torch.rand(1, 256, 256)
+    t2 = torch.rand(1, 256, 256)
+    change = torch.rand(1, 256, 256)
+
+    out = ChangeDetectionModelOutput(
+        t1_semantic_prediction=t1,
+        t2_semantic_prediction=t2,
+        change_prediction=change,
+    )
+
+    print(f"Attribute access: {out.t1_semantic_prediction.shape}")
+    print(f"Dict access:      {out['change_prediction'].shape}")
+
+    print("\nIterating over items:")
+    for k, v in out.items():
+        print(f" - {k}: {v.shape}")
+
+    print("\nLog representation:")
+    print(out)
+
+
+def demo_mask_from_list() -> None:
+    masks = [
+        torch.rand(1, 256, 256),
+        torch.rand(1, 256, 256),
+        torch.rand(1, 256, 256),
+    ]
+    mask = Mask.from_list(masks)
+    print(mask)
+
+
+if __name__ == "__main__":
+    demo_change_detection_output()
+    demo_mask_from_list()

--- a/torchange/utils/mask_data.py
+++ b/torchange/utils/mask_data.py
@@ -10,6 +10,13 @@ import torch
 
 @dataclass
 class Mask:
+    """Container for change detection masks.
+
+    Attributes:
+        change_mask: Required change mask tensor.
+        t1_semantic_mask: Optional semantic mask for time-1.
+        t2_semantic_mask: Optional semantic mask for time-2.
+    """
     change_mask: torch.Tensor
 
     t1_semantic_mask: Optional[torch.Tensor] = None
@@ -17,19 +24,27 @@ class Mask:
 
     @classmethod
     def from_list(cls, mask_list: List[torch.Tensor]):
-        # masks[0] - cls, masks[1] - cls, masks[2] - change
-        # masks[0] - cls, masks[1] - change
-        # masks[0] - change
+        """Create a ``Mask`` from a list of tensors.
+
+        Expected layouts:
+        - [change]
+        - [t1_semantic, change]
+        - [t1_semantic, t2_semantic, change]
+        """
         if len(mask_list) == 1:
             return cls(change_mask=mask_list[-1])
-        elif len(mask_list) == 2:
+        if len(mask_list) == 2:
             return cls(t1_semantic_mask=mask_list[0], change_mask=mask_list[-1])
-        elif len(mask_list) == 3:
-            return cls(t1_semantic_mask=mask_list[0], t2_semantic_mask=mask_list[1], change_mask=mask_list[-1])
-        else:
-            raise ValueError(f"Invalid number of masks: {len(mask_list)}")
+        if len(mask_list) == 3:
+            return cls(
+                t1_semantic_mask=mask_list[0],
+                t2_semantic_mask=mask_list[1],
+                change_mask=mask_list[-1],
+            )
+        raise ValueError(f"Invalid number of masks: {len(mask_list)}")
 
     def items(self) -> Iterator:
+        """Return items for dict-like usage."""
         return self.__dict__.items()
 
     def __repr__(self) -> str:
@@ -42,8 +57,3 @@ class Mask:
             else:
                 info.append(f"{k}={v}")
         return f"{self.__class__.__name__}(\n    " + ",\n    ".join(info) + "\n)"
-
-
-if __name__ == '__main__':
-    m = Mask.from_list([torch.rand(1, 256, 256), torch.rand(1, 256, 256), torch.rand(1, 256, 256)])
-    print(m)

--- a/torchange/utils/outputs.py
+++ b/torchange/utils/outputs.py
@@ -10,15 +10,15 @@ import torch
 
 @dataclass
 class ChangeDetectionModelOutput:
-    """
-    Base output class for the model.
+    """Container for change detection model outputs.
 
-    It behaves like a rigid dataclass (for type safety and IDE autocomplete)
-    but also supports dictionary-like access patterns.
-    Fields:
-    - t1_semantic_prediction: Optional tensor (can be None).
-    - t2_semantic_prediction: Optional tensor (can be None).
-    - change_prediction: Mandatory tensor.
+    This dataclass provides typed attributes and dictionary-style access for
+    flexible downstream usage.
+
+    Attributes:
+        change_prediction: Required change mask/logits tensor.
+        t1_semantic_prediction: Optional semantic prediction for time-1.
+        t2_semantic_prediction: Optional semantic prediction for time-2.
     """
     change_prediction: torch.Tensor
 
@@ -26,46 +26,38 @@ class ChangeDetectionModelOutput:
     t2_semantic_prediction: Optional[torch.Tensor] = None
 
     def __getitem__(self, key: str) -> torch.Tensor:
-        """
-        Allows dictionary-style access: output['key']
-        """
+        """Dictionary-style access, e.g. ``output['change_prediction']``."""
         if hasattr(self, key):
             return getattr(self, key)
         raise KeyError(f"Key '{key}' not found in {self.__class__.__name__}")
 
     def __setitem__(self, key: str, value: torch.Tensor):
-        """
-        Allows dictionary-style assignment: output['key'] = value
-        Only allows setting existing fields to ensure structural integrity.
-        """
+        """Dictionary-style assignment for existing fields only."""
         if not hasattr(self, key):
             raise KeyError(f"Field '{key}' is not a valid field of {self.__class__.__name__}")
         setattr(self, key, value)
 
     def keys(self):
-        """Enables dict(output).keys()"""
+        """Return keys for dict-like usage."""
         return self.__dict__.keys()
 
     def values(self):
-        """Enables dict(output).values()"""
+        """Return values for dict-like usage."""
         return self.__dict__.values()
 
     def items(self) -> Iterator:
-        """Enables dict(output).items()"""
+        """Return items for dict-like usage."""
         return self.__dict__.items()
 
     def __len__(self) -> int:
         return len(self.__dict__)
 
     def to_dict(self) -> Dict[str, torch.Tensor]:
-        """Explicitly convert to a standard Python dictionary."""
+        """Convert to a standard Python dictionary."""
         return asdict(self)
 
     def __repr__(self) -> str:
-        """
-        Custom print format.
-        Safely handles cases where tensors are None.
-        """
+        """Custom representation that handles ``None`` tensors safely."""
         info = []
         for k, v in self.items():
             if v is None:
@@ -75,38 +67,3 @@ class ChangeDetectionModelOutput:
             else:
                 info.append(f"{k}={v}")
         return f"{self.__class__.__name__}(\n    " + ",\n    ".join(info) + "\n)"
-
-
-# --- Usage Example ---
-if __name__ == "__main__":
-    # 1. Simulate dummy tensors
-    t1 = torch.rand(1, 256, 256)
-    t2 = torch.rand(1, 256, 256)
-    change = torch.rand(1, 256, 256)
-
-    # 2. Initialize the object
-    out = ChangeDetectionModelOutput(
-        t1_semantic_prediction=t1,
-        t2_semantic_prediction=t2,
-        change_prediction=change
-    )
-
-    # 3. Attribute Access (Best for IDE autocomplete)
-    print(f"Attribute Access: {out.t1_semantic_prediction.shape}")
-
-    # 4. Dictionary Access (Best for dynamic loops or legacy code)
-    print(f"Dict Access:      {out['change_prediction'].shape}")
-
-    # 5. Iteration
-    print("\nIterating over items:")
-    for k, v in out.items():
-        print(f" - {k}: {v.shape}")
-
-    # 6. Clean Print
-    print("\nLog Representation:")
-    print(out)
-
-    out = ChangeDetectionModelOutput(
-        change_prediction=change
-    )
-    print(out)


### PR DESCRIPTION
### Motivation

- Remove inline runnable code from library modules so utility files remain lightweight and easier to test and statically analyze.
- Provide a minimal, runnable example for users to exercise `ChangeDetectionModelOutput` and `Mask.from_list` without importing example code into the library.
- Remove the previously added README utilities section per feedback to avoid duplicative documentation.

### Description

- Cleaned up `torchange/utils/outputs.py` by adding a concise class docstring, clarifying attribute descriptions, preserving dict-like accessors (`__getitem__`, `__setitem__`, `keys`, `values`, `items`, `to_dict`, `__repr__`), and removing the embedded `__main__` example.
- Tidied `torchange/utils/mask_data.py` by adding a class docstring, documenting and clarifying `Mask.from_list` expected layouts (`[change]`, `[t1_semantic, change]`, `[t1_semantic, t2_semantic, change]`), and removing the inline example and top-level execution block.
- Added `examples/utils_output_masks.py` containing runnable demos for `ChangeDetectionModelOutput` and `Mask.from_list` illustrating construction, attribute and dict access, iteration, and print representation.
- Removed the small utilities section from `README.md` per the requested feedback.

### Testing

- No automated tests were run for these changes since they are documentation and example-focused updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abcd3f2248329bc3334a5c46147f7)