### PR TITLE
Dataset-agnostic training entry point, resume-safe eval callbacks, and an xView2 worked example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dev
 # local uv environment (machine-specific resolution; torchange is a library)
 uv.lock
 uv.toml
+# valid-patch index caches written to cwd by xView2 / HFxView2
+*_valid_indices_*.npy

--- a/examples/xview2_project/README.md
+++ b/examples/xview2_project/README.md
@@ -1,0 +1,177 @@
+## 🚀 xView2 project: Swin-based ChangeOS for building damage assessment
+
+Trains [**ChangeOS**](https://www.sciencedirect.com/science/article/abs/pii/S0034425721003564) with a
+Swin-T backbone on [xView2](https://xview2.org/), scored with the official mixed metric
+(`0.3 * localization F1 + 0.7 * harmonic_mean(damage F1s)`).
+
+Unlike `examples/example_project` (BRIGHT), this project uses the dataset-agnostic entry point
+`torchange.training.bisup_train` — the evaluator is declared in `config.train.callbacks` rather than
+hardcoded in the training script.
+
+### 📊 Performance Summary
+
+Trained on `train`+`tier3`, model selected on `test`, final numbers reported on `hold`.
+
+| arch         | backbone | Overall F1 | Localization F1 | Damage F1 | no-damage | minor | major | destroyed | Weights |
+|:-------------|:---------|:----------:|:---------------:|:---------:|:----------|:------|:------|:----------|:--------|
+| **ChangeOS** | Swin-T   |   76.91    |      85.03      |   73.43   | 89.39     | 58.03 | 72.75 | 81.25     | [🤗link](https://huggingface.co/EVER-Z/torchange_example_changeos_swint_on_xview2_best42k) |
+
+`configs/swint_cos.py` as committed: 60k iters, effective batch 16, poly LR from 6e-5, bf16;
+3 h 16 min on 2 × A100-40GB.
+
+Selection picked step 42,619 of 60,000. `test/final_f1` over training:
+
+| step | 10,654 | 21,309 | 31,964 | **42,619** | 53,274 | 60,000 |
+|:---|:---|:---|:---|:---|:---|:---|
+| final F1 | 75.36 | 75.99 | 76.40 | **76.68** | 76.05 | 75.89 |
+
+The last two evaluations are worse than the best, so the reported model is `model-best.pth`, *not*
+`checkpoint-60000.pth` — which is the point of keeping the two separate.
+
+---
+
+### 1. Data preparation (run once, before training)
+
+Two things happen here, and both must happen **outside** the DDP training job:
+
+1. **Download.** `EVER-Z/torchange_xView2` is ~24 GB (train 2799, tier3 3378, test 933, hold 933).
+   Set `HF_HOME` first if your home directory is small or quota-limited.
+2. **The valid-patch index.** `HFxView2.build_index()` decodes every `t2_mask` and scans
+   6177 × 9 tiles to drop tiles with no damage label, caching the result as
+   `HFxView2_train_tier3_valid_indices_p512_s256.npy` in the **current working directory**. It has no
+   rank guard, so under `torchrun` every rank would redo the whole scan and race on the write.
+
+Driving it from the config guarantees the cache filename matches what training looks for:
+
+```bash
+cd examples/xview2_project
+
+python -c "
+import ever as er
+er.registry.register_all()
+import torchange  # noqa: F401 -- registers HFxView2
+cfg = er.config.import_config('configs/swint_cos.py')
+ds = er.registry.DATASET[cfg.data.train['type']](cfg.data.train['params'])
+print(len(ds), 'valid patches')
+"
+```
+
+Construct the **dataset**, not the dataloader: `er.builder.make_dataloader` would go on to build a
+`StepDistributedSampler`, which raises `Default process group has not been initialized` outside a
+`torchrun` context. Downloading and indexing only need the dataset.
+
+For `train`+`tier3` at 512/256 this keeps **34,081** of 55,593 candidate patches.
+
+### 2. Training
+
+```bash
+cd examples/xview2_project    # cwd matters: er.registry.register_all() and `from configs import ...`
+
+# remove --use_wandb and --project if you don't have a wandb account
+torchrun --nnodes=1 --nproc_per_node=2 --master_port $RANDOM \
+  -m torchange.training.bisup_train \
+  --config_path=configs/swint_cos.py \
+  --model_dir=logs/xview2_swint_cos \
+  --mixed_precision='bf16' \
+  --use_wandb \
+  --project 'torchange_xview2_bench'
+```
+
+Trailing bare `key value` pairs override the config, e.g.
+`data.train.params.batch_size 8`, `train.callbacks.0.params.epoch_interval 5`.
+
+At batch 8 × 2 GPUs the 34,081 patches give 2,130 steps/epoch, so 60k iters ≈ 28 epochs.
+`train.num_iters` is the main knob — keep `learning_rate.params.max_iters` equal to it.
+
+`resume_from_last` defaults to `True` and the config writes a checkpoint every 2 epochs, so an
+interrupted run only needs the same command re-submitted with the same `--model_dir`. The eval
+callback restores its score history from `test_tracked_scores.csv` on restart, so a resume cannot
+replace `model-best.pth` with a worse model or truncate the CSV.
+
+> **On Slurm**, request the GPUs on a *single node* (e.g. `-N 1 -G 2`). Given only `-G 2`, Slurm may
+> allocate one GPU on each of two nodes, and `torchrun --nnodes=1 --nproc_per_node=2` then fails on
+> rank 1 with `CUDA error: invalid device ordinal`. Check with
+> `sacct -j <id> --format=AllocTRES%60` — you want `gres/gpu=2,node=1`.
+
+### 3. Final evaluation on `hold`
+
+The protocol is **train on `train`+`tier3` → select on `test` → report on `hold`**. The training-time
+callback evaluates `test` every 5 epochs and saves `model-best.pth` at the best `test/final_f1`;
+`hold` is touched exactly once, afterwards.
+
+`hold` deliberately is **not** a second training callback. `_xView2StandardEval.func()` writes
+`model-best.pth` whenever *its own* split improves, and both callbacks would write the same
+filename — a `hold` callback would silently overwrite the `test`-selected checkpoint. So it is a
+separate step:
+
+```bash
+cd examples/xview2_project
+torchrun --nnodes=1 --nproc_per_node=2 --master_port $RANDOM eval_hold.py \
+  --model_dir logs/xview2_swint_cos
+```
+
+With no `--checkpoint_name`, `er.infer_tool.build_from_model_dir` loads `model-best.pth` — exactly
+the `test`-selected weights. Results go to `hold_scores.csv` in the model dir. Use
+`--nproc_per_node=1` for a single GPU; torchrun is required either way because
+`er.builder.make_dataloader` constructs a `StepDistributedSampler`.
+
+### 4. Export
+
+```bash
+python -m torchange.utils.push_to_hub model_dir_to_hub \
+  --model_dir logs/xview2_swint_cos \
+  --repo_id <your hf username>/<repo name> \
+  --private
+```
+
+Needs the `hub` extra (`fire` + `huggingface-hub`). Note that `model_dir_to_hub` rebuilds the model
+from `config.pkl`, which — unlike the config `.py` — does not re-run the algorithm import, so import
+`torchange.models.changeos` yourself if you call it from Python rather than the CLI.
+
+### ⚠️ Notes
+
+- **Eval `batch_size` must stay 1.** `torchange/metrics/xview2.py` applies the single-map constraint
+  as `dam_pred = loc_pred * dam_pred` with shapes `(B,1,H,W) * (B,H,W)`, which only broadcasts
+  correctly at `B=1`. `HFxView2StandardEval` hardcodes it.
+- `ChangeOS.set_default_config()` is already xView2-shaped (`loc_head.num_classes=1`,
+  `dam_head.num_classes=5`), so `configs/swint_cos.py` only sets the decoder widths.
+- `HFxView2` has no `ignore_t2_bg` option (only the file-path `xView2` class does), so damage class 0
+  is trained as background — which is what the eval-time single-map constraint assumes.
+- `torchange/models/` is not auto-imported, so the config imports `ChangeOS` itself at the top.
+  Evaluators, datasets and modules are auto-imported and can be named by string in the config.
+
+### 📚 References
+
+```bibtex
+@software{zheng2024torchange,
+  author = {Zheng, Zhuo},
+  title = {torchange: A Unified Change Representation Learning Benchmark Library},
+  url = {https://github.com/Z-Zheng/pytorch-change-models},
+  year = {2024}
+}
+
+@article{zheng2021changeos,
+  title={Building damage assessment for rapid disaster response with a deep object-based semantic change detection framework: From natural disasters to man-made disasters},
+  author={Zheng, Zhuo and Zhong, Yanfei and Wang, Junjue and Ma, Ailong and Zhang, Liangpei},
+  journal={Remote Sensing of Environment},
+  volume={265},
+  pages={112636},
+  year={2021},
+  publisher={Elsevier}
+}
+
+@article{gupta2019xbd,
+  title={xBD: A dataset for assessing building damage from satellite imagery},
+  author={Gupta, Ritwik and Hosfelt, Richard and Sajeev, Sandra and Patel, Nirav and Goodman, Bryce and Doshi, Jigar and Heim, Eric and Choset, Howie and Gaston, Matthew},
+  journal={arXiv preprint arXiv:1911.09296},
+  year={2019}
+}
+
+@inproceedings{liu2021swin,
+  title={Swin transformer: Hierarchical vision transformer using shifted windows},
+  author={Liu, Ze and Lin, Yutong and Cao, Yue and Hu, Han and Wei, Yixuan and Zhang, Zheng and Lin, Stephen and Guo, Baining},
+  booktitle={Proceedings of the IEEE/CVF international conference on computer vision},
+  pages={10012--10022},
+  year={2021}
+}
+```

--- a/examples/xview2_project/configs/comm.py
+++ b/examples/xview2_project/configs/comm.py
@@ -1,0 +1,31 @@
+# Copyright (c) Zhuo Zheng and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+import albumentations as A
+import albumentations.pytorch
+
+# No RandomCrop here: unlike HFBRIGHT, HFxView2 already crops each 1024x1024 image to a
+# `crop_size` tile in compute_tile_slice(). A.D4() is purely geometric, so the 255 ignore
+# values in the damage mask survive it, and to_bitemporal_compose() makes it apply the same
+# geometry to t2_image/t2_mask.
+train_data = dict(
+    train=dict(
+        type='HFxView2',
+        params=dict(
+            hf_repo_name='EVER-Z/torchange_xView2',
+            splits=['train', 'tier3'],
+            training=True,
+            crop_size=512,
+            stride=256,
+            transform=A.Compose([
+                A.D4(),
+                A.Normalize(),
+                A.pytorch.ToTensorV2(),
+            ]),
+            batch_size=8,
+            num_workers=4,
+        ),
+    ),
+)

--- a/examples/xview2_project/configs/swint_cos.py
+++ b/examples/xview2_project/configs/swint_cos.py
@@ -1,0 +1,68 @@
+# Copyright (c) Zhuo Zheng and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+from torchvision.models import Swin_T_Weights
+
+# torchange/models/ is not auto-imported, so importing the model here is what registers
+# ChangeOS/ChangeOSDecoder/ChangeOSHead. import_config() executes this file as a module.
+from torchange.models.changeos import ChangeOS  # noqa: F401
+from configs import comm
+
+# ChangeOS.set_default_config() is already xView2-shaped: loc_head.num_classes=1 (building
+# footprint) and dam_head.num_classes=5 (bg / no-damage / minor / major / destroyed), both at
+# upsample_scale=4. matching the stride-4 decoder output. Only the decoder needs the Swin widths.
+config = dict(
+    model=dict(
+        type='ChangeOS',
+        params=dict(
+            encoder=dict(
+                type='TVSwinTransformer',
+                params=dict(
+                    name='swin_t',
+                    weights=Swin_T_Weights.IMAGENET1K_V1
+                ),
+            ),
+            decoder=dict(
+                in_channels_list=[96 * (2 ** i) for i in range(4)],
+                out_channels=256,
+                fusion_type='2mlps'
+            ),
+        )
+    ),
+    data=comm.train_data,
+    learning_rate=dict(
+        type='poly',
+        params=dict(
+            base_lr=6e-5,
+            power=0.9,
+            max_iters=60000,
+        )
+    ),
+    optimizer=dict(
+        type='adamw',
+        params=dict(
+            weight_decay=0.01
+        ),
+    ),
+    train=dict(
+        torch_compile=dict(),
+        forward_times=1,
+        num_iters=60000,
+        distributed=True,
+        sync_bn=True,
+        log_interval_step=50,
+        # resume_from_last defaults to True, so a walltime kill only needs the same command
+        # re-submitted -- but only if checkpoints were actually written along the way.
+        save_ckpt_interval_epoch=2,
+        ckpt_save_max_keep=3,
+        callbacks=[
+            dict(
+                type='HFxView2StandardEval',
+                params=dict(split='test', epoch_interval=5),
+            ),
+        ]
+    ),
+    test=dict()
+)

--- a/examples/xview2_project/eval_hold.py
+++ b/examples/xview2_project/eval_hold.py
@@ -1,0 +1,104 @@
+# Copyright (c) Zhuo Zheng and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+"""Final evaluation of a trained model_dir on the xView2 `hold` split.
+
+Deliberately NOT a training callback. `_xView2StandardEval.func()` writes `model-best.pth`
+whenever *its own* split improves, so registering a second callback for `hold` would overwrite
+the checkpoint that the `test` split selected. The protocol is:
+
+    train on train+tier3  ->  select on `test` (model-best.pth)  ->  report on `hold`
+
+Must be launched with torchrun even for a single GPU: `er.builder.make_dataloader` constructs a
+StepDistributedSampler, which needs an initialized process group.
+
+    cd examples/xview2_project
+    torchrun --nnodes=1 --nproc_per_node=2 --master_port $RANDOM eval_hold.py \
+      --model_dir logs/xview2_swint_cos
+
+Writes `<split>_scores.csv` into model_dir.
+"""
+import argparse
+import importlib
+import logging
+import os
+
+import albumentations as A
+import albumentations.pytorch
+import ever as er
+import torch
+from ever.core.logger import get_console_file_logger
+from ever.data import as_ddp_inference_loader
+
+import torchange  # noqa: F401 -- registers HFxView2 and the metrics
+from torchange.metrics.xview2 import evaluate
+
+
+def build_dataloader(split, num_workers=2):
+    # batch_size must stay 1: the single-map constraint in metrics/xview2.py multiplies a
+    # (B,1,H,W) localization mask by a (B,H,W) damage map, which only broadcasts at B=1.
+    dataloader = er.builder.make_dataloader(dict(
+        type='HFxView2',
+        params=dict(
+            hf_repo_name='EVER-Z/torchange_xView2',
+            splits=[split],
+            training=False,
+            transform=A.Compose([
+                A.Normalize(),
+                A.pytorch.ToTensorV2(),
+            ]),
+            batch_size=1,
+            num_workers=num_workers,
+        ),
+    ))
+    return as_ddp_inference_loader(dataloader)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model_dir', required=True,
+                        help='training output dir; must contain config.pkl and a checkpoint')
+    parser.add_argument('--checkpoint_name', default=None,
+                        help='default: model-best.pth if present, else the latest checkpoint-*.pth')
+    parser.add_argument('--split', default='hold', choices=['hold', 'test'])
+    parser.add_argument('--num_workers', type=int, default=2)
+    parser.add_argument('--model_module', default='torchange.models.changeos',
+                        help='imported to register the model named in config.pkl. Needed because '
+                             'torchange/models/ is not auto-imported and, unlike the config .py, '
+                             'the pickled config does not re-run that import.')
+    args = parser.parse_args()
+
+    assert 'LOCAL_RANK' in os.environ, 'launch with torchrun (use --nproc_per_node=1 for one GPU)'
+    torch.set_float32_matmul_precision('high')
+    er.registry.register_all()
+    importlib.import_module(args.model_module)
+    er.dist.init_dist_env()
+
+    # checkpoint_name=None -> ever prefers model-best.pth, i.e. exactly the `test`-selected one
+    model, tag = er.infer_tool.build_from_model_dir(
+        model_dir=args.model_dir, checkpoint_name=args.checkpoint_name
+    )
+    model = model.to(er.auto_device()).eval()
+
+    logger = get_console_file_logger(f'eval_{args.split}', logging.INFO, args.model_dir)
+    logger.info(f'model_dir       : {args.model_dir}')
+    logger.info(f'checkpoint      : {args.checkpoint_name or tag}')
+    logger.info(f'evaluation split: {args.split}')
+
+    dataloader = build_dataloader(args.split, num_workers=args.num_workers)
+    scores = evaluate(model, dataloader, logger, args.model_dir, args.split)
+
+    if er.dist.is_main_process():
+        tracker = er.metric.ScoreTracker()
+        tracker.append(scores, 0)
+        out = os.path.join(args.model_dir, f'{args.split}_scores.csv')
+        tracker.to_csv(out)
+        for k, v in scores.items():
+            logger.info(f'{k}: {v:.4f}')
+        logger.info(f'wrote {out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/torchange/__init__.py
+++ b/torchange/__init__.py
@@ -33,5 +33,16 @@ def _import_modules():
             importlib.import_module(full_module_name)
 
 
+def _import_metrics():
+    metric_pkg = __name__ + ".metrics"
+    package_dir = Path(__file__).parent / "metrics"
+    for module_info in pkgutil.iter_modules([str(package_dir)]):
+        if not module_info.name.startswith("_"):
+            full_module_name = f"{metric_pkg}.{module_info.name}"
+            importlib.import_module(full_module_name)
+
+
 _import_dataclass()
 _import_modules()
+# populates er.registry.CALLBACK, so evaluators can be named in config.train.callbacks
+_import_metrics()

--- a/torchange/metrics/_tracker.py
+++ b/torchange/metrics/_tracker.py
@@ -1,0 +1,58 @@
+# Copyright (c) Zhuo Zheng and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+"""Make evaluation callbacks survive a resume.
+
+``er.metric.ScoreTracker`` is in-memory only and its ``to_csv`` rewrites the whole file, while
+``ever`` rebuilds callbacks from scratch on every process start (``Trainer.build_callbacks``).
+``resume_from_last`` therefore restores the model and global_step but *not* the evaluation history,
+so the first evaluation after a restart would overwrite ``model-best.pth`` with a possibly worse
+model and truncate the score CSV to a single row. Seeding the tracker from the CSV it previously
+wrote fixes both.
+"""
+import os
+
+import pandas as pd
+
+__all__ = ['restore_tracker']
+
+
+def restore_tracker(tracker, csv_path, max_step=None):
+    """Repopulate ``tracker`` from a CSV it wrote earlier.
+
+    Parameters
+    ----------
+    tracker : er.metric.ScoreTracker
+        Tracker to seed, expected to be empty.
+    csv_path : str
+        Path the tracker previously wrote with ``to_csv``. Missing file is not an error.
+    max_step : int, optional
+        Drop rows recorded after this step. On resume this is the restored ``global_step``:
+        rows beyond it describe weights that were discarded by rolling back to the checkpoint.
+
+    Returns
+    -------
+    int
+        Number of rows restored.
+    """
+    if not os.path.exists(csv_path):
+        return 0
+
+    df = pd.read_csv(csv_path)
+    if 'step' not in df.columns or len(df) == 0:
+        return 0
+
+    if max_step is not None:
+        df = df[df['step'] <= max_step]
+    if len(df) == 0:
+        return 0
+
+    # Write through the public `scores` view rather than tracker.append(), which would re-emit
+    # every restored point to wandb under a stale step.
+    data = tracker.scores
+    for col in df.columns:
+        data.setdefault(col, []).extend(df[col].tolist())
+
+    return len(df)

--- a/torchange/metrics/scd.py
+++ b/torchange/metrics/scd.py
@@ -10,6 +10,8 @@ from typing import Dict
 import torch
 from tqdm import tqdm
 
+from torchange.metrics._tracker import restore_tracker
+
 __all__ = [
     'MultiClassPixelEval',
 ]
@@ -31,12 +33,34 @@ class MultiClassPixelEval(er.Callback):
         self.dataloader = er.data.as_ddp_inference_loader(dataloader)
         self.score_tracker = er.metric.ScoreTracker()
         self.score_table_name = data_cfg['type']
+        self._restored = False
 
     @property
     def best_key(self):
         return 'eval/mIoU'
 
+    @property
+    def score_csv(self):
+        return os.path.join(self.model_dir, f'{self.score_table_name}_scores.csv')
+
+    def _restore_once(self):
+        """Recover the score history so a resume cannot clobber a better model-best.pth."""
+        if self._restored:
+            return
+        self._restored = True
+
+        n = restore_tracker(self.score_tracker, self.score_csv, max_step=self.global_step)
+        if n == 0:
+            return
+
+        best = self.score_tracker.highest_score(self.best_key)
+        self.logger.info(
+            f'restored {n} previous evaluations, '
+            f'best {self.best_key}: {best[self.best_key]} at step: {best["step"]}'
+        )
+
     def func(self):
+        self._restore_once()
         result = self.evaluate()
         mIoU = result.iou(-3)
 
@@ -46,7 +70,7 @@ class MultiClassPixelEval(er.Callback):
 
         score = self.extract_score(result)
         self.score_tracker.append(score, self.global_step)
-        self.score_tracker.to_csv(os.path.join(self.model_dir, f'{self.score_table_name}_scores.csv'))
+        self.score_tracker.to_csv(self.score_csv)
 
         best_score = self.score_tracker.highest_score(self.best_key)
         self.logger.info(f"best {self.best_key}: {best_score[self.best_key]}, at step {best_score['step']}")

--- a/torchange/metrics/xview2.py
+++ b/torchange/metrics/xview2.py
@@ -14,6 +14,8 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
+from torchange.metrics._tracker import restore_tracker
+
 
 def mixed_score(loc_tb, dam_tb):
     """Compute the xView2 mixed score from localization and damage tables."""
@@ -140,15 +142,40 @@ class _xView2StandardEval(er.Callback):
         self.best_final_f1 = 0.
         self.best_step = 0
         self.split = None
+        self._restored = False
+
+    @property
+    def score_csv(self):
+        return os.path.join(self.model_dir, f'{self.split}_tracked_scores.csv')
+
+    def _restore_once(self):
+        """Recover the score history so a resume cannot clobber a better model-best.pth."""
+        if self._restored:
+            return
+        self._restored = True
+
+        n = restore_tracker(self.tracked_scores, self.score_csv, max_step=self.global_step)
+        if n == 0:
+            return
+
+        key = f'{self.split}/final_f1'
+        best = self.tracked_scores.highest_score(key)
+        self.best_final_f1 = best[key]
+        self.best_step = best['step']
+        self.logger.info(
+            f'restored {n} previous {self.split} evaluations, '
+            f'best final_f1: {self.best_final_f1:.4f} at step: {self.best_step}'
+        )
 
     def func(self):
+        self._restore_once()
         self.logger.info(f'Split: {self.split}')
 
         scores = evaluate(self.unwrapped_model, self.dataloader, self.logger, self.model_dir, self.split)
         self.tracked_scores.append(scores, self.global_step)
 
         if er.dist.is_main_process():
-            self.tracked_scores.to_csv(os.path.join(self.model_dir, f'{self.split}_tracked_scores.csv'))
+            self.tracked_scores.to_csv(self.score_csv)
 
             if scores[f'{self.split}/final_f1'] > self.best_final_f1:
                 self.save_model('model-best.pth')

--- a/torchange/training/bisup_train.py
+++ b/torchange/training/bisup_train.py
@@ -1,0 +1,38 @@
+# Copyright (c) Zhuo Zheng and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+"""Dataset-agnostic bitemporal-supervised training entry point.
+
+Unlike ``bisup_train_bright.py``, no evaluator is hardcoded here. Declare them in
+``config.train.callbacks`` instead; ``ever`` builds them from the ``CALLBACK`` registry:
+
+    train=dict(
+        callbacks=[
+            dict(type='HFxView2StandardEval', params=dict(split='test', epoch_interval=5)),
+        ],
+    )
+"""
+import torch
+
+import ever as er
+from ever.trainer import get_default_parser
+
+# importing the package populates er.registry DATASET/MODEL/CALLBACK from torchange/data/,
+# torchange/module/ and torchange/metrics/, so configs can name any of them.
+# torchange/models/ stays opt-in -- a config must import the algorithm file it uses.
+import torchange  # noqa: F401
+
+if __name__ == '__main__':
+    torch.set_float32_matmul_precision('high')
+    er.registry.register_all()
+
+    parser = get_default_parser()
+    parser.add_argument("--seed", type=int, default=2333)
+    parser.add_argument("--deterministic", action='store_true')
+    trainer, args = er.trainer.get_trainer(parser=parser, return_args=True)
+    er.seed_torch(args.seed, deterministic=args.deterministic)
+
+    trainer: er.trainer.THDDPTrainer
+    trainer.run()


### PR DESCRIPTION
## Summary

Three related changes, one commit each.

**1. `torchange/training/bisup_train.py` — a dataset-agnostic entry point.**
`bisup_train_bright.py` hardcodes `BRIGHTEval`, so a new dataset meant copying the same 29 lines of training glue. That copy is unnecessary: `ever.Trainer.build_callbacks()` already builds evaluators from `config.train.callbacks` via `er.registry.CALLBACK`. The new script hardcodes no evaluator — a config declares

```python
train=dict(callbacks=[
    dict(type='HFxView2StandardEval', params=dict(split='test', epoch_interval=5)),
])
```

and the script stays generic. `bisup_train_bright.py` is untouched, so the documented BRIGHT commands keep working.

This required auto-importing `metrics/` in `torchange/__init__.py` alongside `data/` and `module/`. Previously the only thing registering an evaluator was the explicit `from torchange.metrics.bright import BRIGHTEval` in the BRIGHT script, so a generic entry point died in `make_callback` with `<name> is not support now`. `torchange/models/` stays opt-in.

**2. Eval callbacks no longer lose their score history on resume.** This is a real bug on any interrupted run. `ScoreTracker` is in-memory only and its `to_csv` rewrites the whole file, while `ever` rebuilds callbacks on every process start. `resume_from_last` restored the model but not the callback, so after a restart:

- `best_final_f1` was back to `0` (and `MultiClassPixelEval`'s tracker empty, so `highest_score` returned `-inf`), and the first evaluation overwrote `model-best.pth` **unconditionally** — replacing the best checkpoint with a possibly worse one;
- `to_csv` truncated `<split>_tracked_scores.csv` to a single row.

`metrics/_tracker.py::restore_tracker` seeds a fresh tracker from the CSV it wrote before; both callbacks call it once via `_restore_once()`. Rows past the resumed `global_step` are dropped, since they describe weights the rollback discarded. It writes through the public `scores` view rather than `append()`, which would re-emit restored points to wandb under stale steps.

**3. `examples/xview2_project/` — Swin-T ChangeOS on xView2.** Exercises the generic entry point end to end and is the second worked benchmark alongside `example_project` (BRIGHT).

## Results

Protocol: train on `train`+`tier3` → select on `test` → report on `hold`.

| arch | backbone | Overall F1 | Loc F1 | Dam F1 | no-damage | minor | major | destroyed |
|:---|:---|:---:|:---|:---|:---|:---|:---|:---|
| ChangeOS | Swin-T | **76.91** | 85.03 | 73.43 | 89.39 | 58.03 | 72.75 | 81.25 |

60k iters, effective batch 16, bf16, 3 h 16 min on 2× A100-40GB.

`test/final_f1` over training: 75.36 (10,654) → 75.99 (21,309) → 76.40 (31,964) → **76.68 (42,619)** → 76.05 (53,274) → 75.89 (60,000).

Note the last two evaluations are worse than the best, so the released weights are `model-best.pth` at step 42,619, **not** `checkpoint-60000.pth`. Taking the final checkpoint would have cost ~0.8 F1 — which is why `hold` is scored by `eval_hold.py` after training rather than by a second callback: every `_xView2StandardEval` writes `model-best.pth` when its own split improves, so a `hold` callback would clobber the `test`-selected checkpoint.

Weights: https://huggingface.co/EVER-Z/torchange_example_changeos_swint_on_xview2_best42k

## Testing

- `pytest tests` — 21 passed, plus the 2 failures that predate this branch (`test_changestar2_forward_eval`, `test_changesparse_o2m_forward_eval`, both test-side bugs from 54dd72b). No regression from the `torchange/__init__.py` change.
- `restore_tracker` unit-checked: 3 rows restored with best correctly identified; `max_step` drops stale rows; missing CSV returns 0; the CSV keeps the full curve after a simulated resume.
- Full training run and `eval_hold.py` executed on 2 GPUs; `from_pretrained` on the published repo returns weights whose 373 tensors are all `torch.equal` to `model-best.pth`.

## Notes

- `ChangeOS.set_default_config()` is already xView2-shaped (`loc_head` 1 class, `dam_head` 5), so the config only sets the Swin decoder widths.
- `HFxView2.build_index()` has no rank guard, so the valid-patch index must be built once single-process before any `torchrun` job — and by constructing the *dataset*, not the dataloader. Documented in the example README.
- Eval `batch_size` must stay 1; the single-map constraint `loc_pred * dam_pred` only broadcasts at B=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)